### PR TITLE
Remove dependency on de.appplant.cordova.common.registerusernotificationsettings

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -67,7 +67,7 @@
     <!-- ios -->
     <platform name="ios">
 
-        <dependency id="de.appplant.cordova.common.registerusernotificationsettings" />
+        <dependency id="cordova-plugin-app-event" />
 
         <config-file target="config.xml" parent="/*">
             <feature name="Badge">

--- a/src/ios/APPBadge.m
+++ b/src/ios/APPBadge.m
@@ -23,7 +23,7 @@
 
 #import "APPBadge.h"
 #import "UIApplication+APPBadge.h"
-#import "AppDelegate+APPRegisterUserNotificationSettings.h"
+#import "AppDelegate+APPAppEvent.h"
 
 @interface APPBadge ()
 


### PR DESCRIPTION
* Fixes #51 
* Rely on `cordova-plugin-app-event` instead of the now deprecated `de.appplant.cordova.common.registerusernotificationsettings`

This allows `cordova-plugin-badge` to co-exist with `cordova-plugin-local-notifications`