### PR TITLE
Fix iOS 15 detection

### DIFF
--- a/www/badge.js
+++ b/www/badge.js
@@ -18,7 +18,7 @@
 var exec      = require('cordova/exec'),
     channel   = require('cordova/channel'),
     ua        = navigator.userAgent.toLowerCase(),
-    isIOS     = ua.indexOf('ipad') > -1 || ua.indexOf('iphone') > -1,
+    isIOS     = ua.indexOf('applewebkit') > -1 || ua.indexOf('ipad') > -1 || ua.indexOf('iphone') > -1,
     isMac     = ua.indexOf('macintosh') > -1,
     isWin     = window.Windows !== undefined,
     isAndroid = !isWin && ua.indexOf('android') > -1,


### PR DESCRIPTION
With the release of iOS 15 (Sept 20th 2021) the user-agent has changed such that the terms `ipad` and `iphone` no longer appear.

e.g. a device running iOS 15.3.1

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.3 Safari/605.1.15
```